### PR TITLE
Fix to overflow issues to layout issue on smaller screens

### DIFF
--- a/css/layouts/blog.css
+++ b/css/layouts/blog.css
@@ -158,21 +158,33 @@ h3 {
 @media (min-width: 48em) {
     .content {
         padding: 2em 3em 0;
-        margin-left: 25%;
     }
 
     .header {
         margin: 60% 2em 0;
         text-align: right;
     }
-
-    .sidebar {
-        position: fixed;
-        top: 0;
-        bottom: 0;
-    }
-
+    
     .footer {
         text-align: center;
     }
+}
+table {
+  overflow-x: auto;
+  display: block;
+}
+
+.footer .pure-menu-horizontal {
+  white-space: normal;
+}
+
+table th:last-child {
+  text-align: center;
+}
+table td:last-child {
+  text-align: center;
+}
+.pure-menu ul {
+  padding: 0;
+  text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 <body>
 
 <div id="layout" class="pure-g">
-  <div class="sidebar pure-u-1 pure-u-md-1-5">
+  <div class="sidebar pure-u-1 pure-u-md-1-3 pure-u-lg-1-4">
     <div class="header">
       <h1 class="brand-title">Calendar</h1>
       <h3 class="brand-tagline"><a href="https://twitter.com/hashtag/timstwitterlisteningparty?src=hash">#timstwitterlisteningparty</a>
@@ -69,7 +69,7 @@
 
   </div>
 
-  <div class="content pure-u-1 pure-u-md-3-4">
+  <div class="content pure-u-1 pure-u-md-2-3 pure-u-lg-3-4">
     <div>
       <!-- A wrapper for all the posts -->
       <div class="posts">


### PR DESCRIPTION
Tables don't work well in a responsve layout. The best you can do (apart from changing the design of the table from rows to columns some how) is to allow scrolling on smaller screens. It's not ideal but its better to scroll the table rather than the window.

Your text was overlapping in the sidebar because your twitter handle is one long word which means it can't wrap like a sentance would do. It needs to have spaces to wrap. The solution is to give it more room or reduce the font size. Or you can force a word break, but its unpredictable.

Changes:
Added better md and lg breakpoints. Make tables scroll when available width is limited. Make footer links wrap when space limited and center text. Center twitter links for better look. Removed some styling which was preventing the layout being responsive.